### PR TITLE
Add network infrastructure for AWS ECS.

### DIFF
--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -48,7 +48,7 @@ resource "aws_internet_gateway" "internet_gateway" {
 
 resource "aws_route_table" "route_table" {
   vpc_id = aws_vpc.main.id
-  route = {
+  route {
     cidr_block = "0.0.0.0/0"
     gateway_id = aws_internet_gateway.internet_gateway.id
   }

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -16,3 +16,71 @@ terraform {
 provider "aws" {
   region = var.region
 }
+
+resource "aws_vpc" "main" {
+  cidr_block           = var.cidr_block
+  enable_dns_hostnames = true # Not sure what it is for
+  tags = {
+    Name = "main"
+  }
+}
+
+resource "aws_subnet" "subnet1" {
+  vpc_id                  = aws_vpc.main.id
+  cidr_block              = cidrsubnet(aws_vpc.main.cidr_block, 8, 1)
+  map_public_ip_on_launch = true
+  availability_zone       = "us-east-1a"
+}
+
+resource "aws_subnet" "subnet2" {
+  vpc_id                  = aws_vpc.main.id
+  cidr_block              = cidrsubnet(aws_vpc.main.cidr_block, 8, 2)
+  map_public_ip_on_launch = true
+  availability_zone       = "us-east-1b"
+}
+
+resource "aws_internet_gateway" "internet_gateway" {
+  vpc_id = aws_vpc.main.id
+  tags = {
+    Name = "internet_gateway"
+  }
+}
+
+resource "aws_route_table" "route_table" {
+  vpc_id = aws_vpc.main.id
+  route = {
+    cidr_block = "0.0.0.0/0"
+    gateway_id = aws_internet_gateway.internet_gateway.id
+  }
+}
+
+resource "aws_route_table_association" "subnet1_route" {
+  subnet_id      = aws_subnet.subnet1.id
+  route_table_id = aws_route_table.route_table.id
+}
+
+resource "aws_route_table_association" "subnet2_route" {
+  subnet_id      = aws_subnet.subnet2.id
+  route_table_id = aws_route_table.route_table.id
+}
+
+resource "aws_security_group" "security_group" {
+  name   = "ecs_security_group"
+  vpc_id = aws_vpc.main.id
+
+  ingress {
+    from_port   = 0
+    to_port     = 0
+    protocol    = -1
+    self        = "false"
+    cidr_blocks = ["0.0.0.0/0"]
+    description = "any"
+  }
+
+  egress {
+    from_port   = 0
+    to_port     = 0
+    protocol    = "-1"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+}

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -41,7 +41,7 @@ variable "tags" {
   }
 }
 
-variable "vpc_cidr_block" {
+variable "cidr_block" {
   type    = string
   default = "10.0.0.0/16"
 }


### PR DESCRIPTION
Network infrastructure includes:
  - VPC
  - Subnets (subnet1 and subnet2)
  - Internet Gateway
  - Route Table
  - Route Table Association
  - Security Group